### PR TITLE
Protractor issue

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -456,9 +456,7 @@ module.exports = function (grunt) {
 
     protractor: {
       options: {
-        args: {
-          seleniumServerJar: '/usr/local/lib/node_modules/protractor/selenium/selenium-server-standalone-2.45.0.jar'
-        },
+
         keepAlive: false, // If false, the grunt process stops when the test fails.
         noColor: false // If true, protractor will not use colors in its output.
       },

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ To run this website project on your development environment, please follow these
   bower install
   ```
 
-3. [node-imagemagick](https://github.com/yourdeveloper/node-imagemagick) uses a default path for the 'convert' and 'identify' utilities that cannot be modified from the [imagemagick-stream](https://github.com/eivindfjeldstad/imagemagick-stream) library. You may need to perform a symlink to these tools' hardcoded paths in order to get imagemagick to work. These instructions may apply to you if you use automated tools  (e.g. [Boxen](https://boxen.github.com/)) to configure your environment using non-default paths.
+3. Run ```node_modules/protractor/bin/webdriver-manager update```
+
+4. [node-imagemagick](https://github.com/yourdeveloper/node-imagemagick) uses a default path for the 'convert' and 'identify' utilities that cannot be modified from the [imagemagick-stream](https://github.com/eivindfjeldstad/imagemagick-stream) library. You may need to perform a symlink to these tools' hardcoded paths in order to get imagemagick to work. These instructions may apply to you if you use automated tools  (e.g. [Boxen](https://boxen.github.com/)) to configure your environment using non-default paths.
 
   ```bash
   sudo mkdir -p /usr/local/bin

--- a/server.js
+++ b/server.js
@@ -4,7 +4,8 @@ var express = require('express'),
     path = require('path'),
     fs = require('fs'),
     mongoose = require('mongoose'),
-    formsAngular = require('forms-angular');
+    formsAngular = require('forms-angular'),
+    fngJqUpload = require('fng-jq-upload');
 
 /**
  * Main application file
@@ -22,7 +23,7 @@ require('./lib/config/express')(app);
 
 var fngHandler = new (formsAngular)(app, {
   urlPrefix: '/api/',
-  JQMongoFileUploader: {}
+  JQMongoFileUploader: {module: fngJqUpload.Controller}
 });
 
 // Bootstrap forms-angular controlled models


### PR DESCRIPTION
There are 3 changes.
Gruntfile.js: removed the hardcoded dependency to the global selenium jar file. In tandem with this
Readme.md has been updated to include a step to ensure that selenium driver is installed.

Update to the server.js file to inject the dependency to the fng-jq-upload module for the forms-angular library.
The forms-angular library should be updated to remove the dependency on line 45 of data_form.js. 